### PR TITLE
Fix: take into account align for navigation

### DIFF
--- a/src/Keyboard.js
+++ b/src/Keyboard.js
@@ -295,9 +295,10 @@ export default class Keyboard extends Lightning.Component {
             else {
                 const targetRow = this.rows[targetIndex];
                 const currentKey = this.currentKeyWrapper;
-                const currentX = this.rows[this._rowIndex].x + currentKey.x;
+                const currentRow = this.rows[this._rowIndex];
+                const currentX = currentRow.x - (currentRow.w * currentRow.mountX)  + currentKey.x;
                 const m = targetRow.children.map((key) => {
-                    const keyX = targetRow.x + key.x;
+                    const keyX = targetRow.x - (targetRow.w * targetRow.mountX) + key.x;
                     if(keyX <= currentX && currentX < keyX + key.w) {
                         return (keyX + key.w) - currentX;
                     }


### PR DESCRIPTION
When using align 'center' or 'right' on the keyboard such as in image, navigation wouldn't happen from (e.g.) L->M when pressing down.
![image](https://user-images.githubusercontent.com/93185618/139020010-09b1eae9-370d-4bf5-956a-aaa06a7f3a8d.png)
