### PR TITLE
(Re)set keyboard.js buffer when setting new inputfield

### DIFF
--- a/src/Keyboard.js
+++ b/src/Keyboard.js
@@ -123,7 +123,7 @@ export default class Keyboard extends Lightning.Component {
             const currentPosition = rowPosition + (marginTop|| margin);
             rowPosition = currentPosition + rowHeight + (marginBottom || margin || verticalSpacing);
             return {
-                ref: `Row-${rowIndex + 1}`, 
+                ref: `Row-${rowIndex + 1}`,
                 x: rowOffset,
                 mountX: rowMount,
                 w: keyPosition,
@@ -213,7 +213,7 @@ export default class Keyboard extends Lightning.Component {
             return;
         }
         const eventData = {
-            previousInput: this._input, 
+            previousInput: this._input,
             input: this._input = input
         };
         if(this._inputField && this._inputField.onInputChanged) {
@@ -255,7 +255,7 @@ export default class Keyboard extends Lightning.Component {
     clear() {
         this._changeInput('');
     }
-    
+
     layout(key) {
         if(key === this._layout) {
             return;
@@ -285,7 +285,7 @@ export default class Keyboard extends Lightning.Component {
             this._previous = null;
             return this._columnIndex = targetIndex;
         }
-        if(direction === 'column' && targetIndex > -1 && targetIndex < this.rows.length ) {    
+        if(direction === 'column' && targetIndex > -1 && targetIndex < this.rows.length ) {
             const currentRowIndex = this._rowIndex;
             const currentColumnIndex = this._columnIndex;
             if(this._previous && this._previous.row === targetIndex) {

--- a/src/Keyboard.js
+++ b/src/Keyboard.js
@@ -269,11 +269,15 @@ export default class Keyboard extends Lightning.Component {
 
     inputField(component) {
         if(component && component.isComponent) {
-            if(component.input !== undefined)
-                this._input = component.input;
+            this._rowIndex = 0;
+            this._columnIndex = 0;
+            this._input = component.input !== undefined? component.input : '';
             this._inputField = component;
         }
         else {
+            this._rowIndex = 0;
+            this._columnIndex = 0;
+            this._input = ''
             this._inputField = undefined;
         }
     }

--- a/src/Keyboard.js
+++ b/src/Keyboard.js
@@ -269,6 +269,8 @@ export default class Keyboard extends Lightning.Component {
 
     inputField(component) {
         if(component && component.isComponent) {
+            if(component.input !== undefined)
+                this._input = component.input;
             this._inputField = component;
         }
         else {


### PR DESCRIPTION
When re-using the keyboard for multiple input fields, the value of the first selected would be written to the second due to the keyboard.js buffer having the previous value.

Set the buffer to the value of the inputField being set or simply empty string.