### PR TITLE
Cleared _previous in Grid's clear()

### DIFF
--- a/src/Grid.js
+++ b/src/Grid.js
@@ -32,6 +32,7 @@ export default class Grid extends CollectionWrapper {
         super.clear();
         this._mainIndex = 0;
         this._crossIndex = 0;
+        this._previous = undefined;
     }
 
     setIndex(index) {


### PR DESCRIPTION
This is a fix for #11 
If the grid is cleared, we should also clear the state of the previously focused element since the focus is reset.