### PR TITLE
Documentation fix for missing index.md file

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,19 @@
+# Lightning UI Reference
+
+Lightning-UI provides a set of components that are used very often when you are developing in Lightning, with the following components we hope to help you out with setting up your app a bit faster:
+
+<!---TOC_start--->
+* [Collection Wrapper](CollectionWrapper/index.md)
+  * [List](CollectionWrapper/List.md)
+  * [Carousel](CollectionWrapper/Carousel.md)
+  * [Grid](CollectionWrapper/Grid.md)
+* [Keyboard](Keyboard/index.md)
+  * [InputField](Keyboard/InputField.md)
+  * [Key](Keyboard/Key.md)
+* [Scrolling Label](ScrollingLabel.md)
+<!---TOC_end--->
+
+# Examples
+In the following repository you can find code examples on how to use the components:
+
+[UI-component-examples](https://github.com/mlapps/ui-component-examples)


### PR DESCRIPTION
- adds the missing main `index.md` file for `docs/` directory. The `index.md` file _[created by @michielvandergeest before]_ comes from the lightningjs.io repo.
- adds missing links to `index.md` to include new documents.
- adds markdown comments [`TOC_start` and `TOC_end`] to make the links easily parseable.