### PR TITLE
Reset scrollTransition when CollectionWrapper is cleared

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/src/helpers/CollectionWrapper.js
+++ b/src/helpers/CollectionWrapper.js
@@ -96,6 +96,9 @@ export default class CollectionWrapper extends Lightning.Component {
         this._uids = [];
         this._items = [];
         this._index = 0;
+        if (this._scrollTransition) {
+            this._scrollTransition.reset(0, 1);
+        }
         if(this.wrapper) {
             const hadChildren = this.wrapper.children > 0;
             this.wrapper.patch({


### PR DESCRIPTION
**Context**
When the Grid component is used and the items are being set again, it first does a call to the internal `clear()` method. Even though this works fine, there does seem to be a bug concerning the scrollTransition. When the Grid is scrolled and cleared, it appeared to be the case that the scrollTransition would consider the last (scrolled) position to be the actual position. This can lead to items being offscreen, even if the index of the Grid is set again. 

Use case 1: When navigating to a new page by using `Router.navigate('some-route', { keepAlive: true})`, pressing the back button and restoring the items and index manually

**Before fix**

https://user-images.githubusercontent.com/6898404/182632442-269e43e2-4c79-41e9-877e-2c78043a3639.mov

**After fix**

https://user-images.githubusercontent.com/6898404/182632763-fe563d4d-89ad-47e4-b6d0-6d470c41956d.mov

Use case 2: By clearing items on the page itself and restoring them by setting `this.tag('Grid').items = someArray` again
**Before fix**

https://user-images.githubusercontent.com/6898404/182632555-8d1b2c73-7a64-4dba-a0be-fae83c9a79da.mov

**After fix**

https://user-images.githubusercontent.com/6898404/182632622-e51fa373-4455-4e51-b963-13500f060f45.mov


**Code example**
I setup a branch in a personal repository, where the code can be found of the application you see in the videos, so that you can see what's going on: 
https://github.com/robbertvancaem/lightning-cypress-test/tree/focus-bug-off-screen-grid-item 
