### PR TITLE
Grid: setIndex change to sync, immediate makes sync patch

### DIFF
--- a/src/List.js
+++ b/src/List.js
@@ -72,12 +72,13 @@ export default class List extends CollectionWrapper {
             }
         });
         wrapper.children = newChildren;
-        const animationDuration = immediate ? 0 : 0.2
         animateItems.forEach((index) => {
             const item = wrapper.children[index];
-            item.patch({
-                smooth: {x: [item.assignedX, { duration: animationDuration }], y: [item.assignedY, { duration: animationDuration }]}
-            });
+            if (immediate) {
+                item.patch({ x: item.assignedX, y: item.assignedY })
+            } else {
+                item.patch({ smooth: { x: item.assignedX, y: item.assignedY }})
+            }
         })
         this._resizeWrapper(crossSize);
     }

--- a/src/helpers/CollectionWrapper.js
+++ b/src/helpers/CollectionWrapper.js
@@ -98,6 +98,7 @@ export default class CollectionWrapper extends Lightning.Component {
                     this.clear();
                 }
 
+                const type = typeof response;
                 if ((Array.isArray(response) && response.length > 0) || type === 'object' ||  type === 'string' || type === 'number') {
                     this.add(response);
                     obj.dataLength = this._items && this._items.length || 0;


### PR DESCRIPTION
This fixes:
- forgotten Grid setIndex that is async and should now be sync
- undefined `type` variable on requestItems
- immediate option on setIndex (and other methods) patch is now sync instead of an async (with duration: 0)