### PR TITLE
fix/collectionwrapper: add missing parameter on remove method

### DIFF
--- a/src/helpers/CollectionWrapper.js
+++ b/src/helpers/CollectionWrapper.js
@@ -222,7 +222,7 @@ export default class CollectionWrapper extends Lightning.Component {
                     if(i === this._items.length-1 && item.hasFocus()) {
                         this._index = this._index - 1;
                     }
-                    return this.removeAt(i, options);
+                    return this.removeAt(i, 1, options);
                 }
             }
         }


### PR DESCRIPTION
Fix a missing `amount` parameter that is not being sent to `removeAt` method inside `remove` method.