### PR TITLE
fix: fix navigation getting stuck while requesting items

### DIFF
--- a/src/Grid.js
+++ b/src/Grid.js
@@ -40,11 +40,10 @@ export default class Grid extends CollectionWrapper {
     }
 
     setIndex(index, options = {}) {
-        if (this._requestsEnabled && this._requestingItems) {
-          return true;
-        }
         if (this._requestsEnabled && (index > this._items.length - 1)) {
-            this._requestMore(index, [], options);
+            if (!this._requestingItems) {
+                this._requestMore(index, [], options);
+            }
             return true;
         }
         if(this._items.length === 0) {

--- a/src/helpers/CollectionWrapper.js
+++ b/src/helpers/CollectionWrapper.js
@@ -155,11 +155,10 @@ export default class CollectionWrapper extends Lightning.Component {
     }
 
     setIndex(index, options = {}) {
-        if (this._requestsEnabled && this._requestingItems) {
-          return true;
-        }
         if (this._requestsEnabled && (index > this._items.length - 1)) {
-            this._requestMore(index, [], options);
+            if (!this._requestingItems) {
+                this._requestMore(index, [], options);
+            }
             return true
         }
         if(this._items.length === 0) {


### PR DESCRIPTION
This PR fixes the navigation getting stuck when the `onRequestItems` callback takes a while to resolve.

We should allow navigation if it is within the current items length.