### PR TITLE
collectionwrapper: reset transition only if it is running

### DIFF
--- a/src/helpers/CollectionWrapper.js
+++ b/src/helpers/CollectionWrapper.js
@@ -176,7 +176,7 @@ export default class CollectionWrapper extends Lightning.Component {
         this._uids = [];
         this._items = [];
         this._index = 0;
-        if (this._scrollTransition) {
+        if (this._scrollTransition && this._scrollTransition.isRunning()) {
             this._scrollTransition.reset(0, 1);
         }
         if(this.wrapper) {
@@ -244,9 +244,9 @@ export default class CollectionWrapper extends Lightning.Component {
         return item;
     }
 
-    reload(item) {
+    reload(item, options = {}) {
         this.clear();
-        this.add(item)
+        this.add(item, options)
     }
 
     plotItems(options = {}) {


### PR DESCRIPTION
Currently, there is an issue when using the `reload()` method that, when it internally calls the `clear()` method it resets the transition even when it is not running, causing sometimes the _wrapper_ x or y (depending of the direction) to be set to _0_ overriding the `scrollCollectionWrapper()` value that was set.

You can see this behaviour by navigating the first List to the index 3, navigate until the last List and then straight back to the first one. You'll see that the _wrapper_ x property is set to _0_ instead of the correct scroll value.

[Example](https://lightningjs.io/playground/#N4IgJgpgDhB2mwMYEsIGcQC5QAEA2yA5gBYAusyshAVmgPSID2AThFiGaVGpnQ2LAB0aANYBPKAENEIwZABudfETIUqtBiwg4ATIICMABkGGQAGhDKS5SjXoBXZO07de-IaInTZCpQWtqdnSOIAC+FmiIzMhQpBjYIHiS9kjEgrRYoABmyHhsmInJqekYFkyQ7MgAtlAspAAEAIJQUPVZzIxV9QDkgnTNUCXdANwAOrDjTLBoDYyxyIzT9QC89cAzkoQQmGsA7jv6AJw6hmb1xAeGAByn9Yh5kswAwox4LDuGAB6GP78-oaExkhFjN6pIWit6rAILsmi0ABRzUgLaYASiBYEYiHsVTgpEEACNGGAxIJwTB4E9iLkwPDycJSJsIIItqQnpJYPJJGh4aj0eZwNA4AgUOgsABtEB9AYlEAAXXCIBlGQSOTy7GVpRA5XyIGqtWYDQAMiobFQ2h0ut0rKpbBomKwRuN9XU1vUTaDQhbOj0bWago5uuNg9DPgaGpAssk8A17ty0HDWhBPqRhQmTQFbIIBgREJJkYs1uN6iX6htkYh6gB9VM1JKp3lF2Cllv1VikezMZvAYutvsANQghuQebwHtIOx7zb7M5LpAk23dyBmZl7s77YGQrEQBdgO26TDwONg3VX0-XrbQUhQVEuZ4vff29SOJ3vD5bF2f11Oa-f9WQtY8PU4q-n+pbAPU84wDsAASLDIAAXosjJjsupBnABEBVAAkvAyYfPU4SgWBbpQYucHREhsAoeOGG1rhkCfARRHniRJYQWRsHwVRNFoXRWEMfh9SGIRb5sexkELlxlHIZIqErv+9F4UxwmicRF5yuprahFpOmsXpv5VqyABiWL2GgEC0qiTazu2nbNqQ1JoIIjKEPC3SDsOo7jt0qK-npBlIEkaAJhRiGyfJDTJqm8DpqagSCC8NSLHiNmluWI7VrWUD1hAjZTrZEAdl2aUXmFPFyeOk5abOnFLiuNUzle0i2HejV9mgRCwHJQEQYsgmfFSHJbGA+5Vv1ylDVQlndIR7VzaxLZeqW-khi2VYEo4eBWaVraOcughVphVQJqs4qaYtpZZCw9TwnkDTIJChjDP+9QADxfi9yAANTfdZBUPvtzlHYBghQOZxDwsAdXYbWZxJASEB4DsyChH5l0lnpS1raWVZwJIBJ5PlWlAy5mzueVEU+aigisG8ki0qTINYWg6Mk05ZNud0lPUZVaG+cIRUDfCTPHQN9QAD4S8J6PYxMrFGUVpnYhZO0A32dklaTrkU9xVP87LpaBetE2MVNI1Q-+ymEf97MHczOHW6slCMat8sthZD1KYx8JckeEC2xjkEcw74urH79gQHbzk69zeu85FAsu8mkKi97yZu7+rKKQJynE0HmsOSHYvKZnrEZZW2e7MgYCOfnhXFc2L6GGXHuMhW9TZ8QECmvXM6F-UACsPxu4FcYhfUsNYfU0VpkumZUIlnS1NC1G7RXWVYTl+Z5YHDf2bthU7jspDMJHYnroe7zCZ8iCID8d8-Ge81GgTSPVUHtXRfuhhBp-Ru6RbK3XG10VZ9z7KTKQpBECQwglfZgHxb532QT8G2wCSxVhSKA8y4C9ocygTAy28DEGP0MKQtB+kcYlk9vUBGSNfZyUjnvGckD8yEIgq-RGyNSLf3qAAZVPrYBh-trIAkNpjKhZZ26ZSrjXOuzCNZFQPsPFulD3bpWkZXIq5we7WFwS2AeKjR4CkgBSEUqB4iSj9IEe0WgBTWLtA4JwCpFSMgJPEEAck8BhCAA)


https://github.com/rdkcentral/Lightning-ui/assets/96475496/9fb0a19f-06bc-455c-b94e-f4c24bbda362

