### PR TITLE
fix: CollectionWrapper immediate option when component is active

### DIFF
--- a/src/helpers/CollectionWrapper.js
+++ b/src/helpers/CollectionWrapper.js
@@ -147,8 +147,8 @@ export default class CollectionWrapper extends Lightning.Component {
                             resolve(true);
                         }
                     } else {
-                        this._requestingItems = false;
-                        resolve(false);
+                      this._requestingItems = false;
+                      resolve(false);
                     }
                 });
         })
@@ -392,12 +392,12 @@ export default class CollectionWrapper extends Lightning.Component {
         }
 
         if (this.active && !isNaN(scroll) && this._scrollTransition) {
-            if (this._scrollTransition.isRunning()) {
-                this._scrollTransition.reset(scroll, 0.05);
+            if (immediate) {
+                this._scrollTransition.updateTargetValue(scroll);
+                this._scrollTransition.finish();
             } else {
-                if (immediate) {
-                    this._scrollTransition.updateTargetValue(scroll);
-                    this._scrollTransition.finish();
+                if (this._scrollTransition.isRunning()) {
+                    this._scrollTransition.reset(scroll, 0.05);
                 } else {
                     this._scrollTransition.start(scroll);
                 }
@@ -494,13 +494,13 @@ export default class CollectionWrapper extends Lightning.Component {
         return array.map((item, index) => {
             return this._normalizeDataItem(item) || index;
         })
-            .filter((item) => {
+        .filter((item) => {
             if(!isNaN(item)) {
-                    console.warn(`Item at index: ${item}, is not a valid item. Removing it from dataset`);
-                    return false;
-                }
-                return true;
-            });
+                console.warn(`Item at index: ${item}, is not a valid item. Removing it from dataset`);
+                return false;
+            }
+            return true;
+        });
     }
 
     _normalizeDataItem(item, index) {

--- a/src/helpers/CollectionWrapper.js
+++ b/src/helpers/CollectionWrapper.js
@@ -147,8 +147,8 @@ export default class CollectionWrapper extends Lightning.Component {
                             resolve(true);
                         }
                     } else {
-                      this._requestingItems = false;
-                      resolve(false);
+                        this._requestingItems = false;
+                        resolve(false);
                     }
                 });
         })
@@ -391,15 +391,19 @@ export default class CollectionWrapper extends Lightning.Component {
             }
         }
 
-        if(!immediate && this.active && !isNaN(scroll) && this._scrollTransition) {
-            if(this._scrollTransition.isRunning()) {
+        if (this.active && !isNaN(scroll) && this._scrollTransition) {
+            if (this._scrollTransition.isRunning()) {
                 this._scrollTransition.reset(scroll, 0.05);
-            }
-            else {
-                this._scrollTransition.start(scroll);
+            } else {
+                if (immediate) {
+                    this._scrollTransition.updateTargetValue(scroll);
+                    this._scrollTransition.finish();
+                } else {
+                    this._scrollTransition.start(scroll);
+                }
             }
         }
-        else if(!isNaN(scroll)) {
+        else if (!isNaN(scroll)) {
             this.wrapper[main] = scroll
         }
     }
@@ -490,13 +494,13 @@ export default class CollectionWrapper extends Lightning.Component {
         return array.map((item, index) => {
             return this._normalizeDataItem(item) || index;
         })
-        .filter((item) => {
+            .filter((item) => {
             if(!isNaN(item)) {
-                console.warn(`Item at index: ${item}, is not a valid item. Removing it from dataset`);
-                return false;
-            }
-            return true;
-        });
+                    console.warn(`Item at index: ${item}, is not a valid item. Removing it from dataset`);
+                    return false;
+                }
+                return true;
+            });
     }
 
     _normalizeDataItem(item, index) {


### PR DESCRIPTION
Using the _options_ parameter on methods like _setIndex_ (eg.: `setIndex(4, { immediate: true })`) in some occasions, even though it tries to set the property (`x` or `y`, depends on the direction) it has no effect.

To fix this, when the component is active and the `immediate` property has been set, it updates the target value of the scroll transition and abruptly finishes it so we see no animation visually.