### PR TITLE
Fix Carousel setIndex when component is inactive

### DIFF
--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -283,7 +283,7 @@ export default class Carousel extends CollectionWrapper {
             const {main, mainDim, directionIsRow} = this._getPlotProperties(this._direction);
             const bound = this[mainDim];
             const viewboundMain = directionIsRow ? 1920 : 1080;
-            const offset = this._scrollTransition && this._scrollTransition.targetValue || 0;
+            const offset = this.wrapper[main];
 
             const boundStart =  -viewboundMain * 0.66;
             const boundEnd = bound + viewboundMain * 0.66;

--- a/src/helpers/CollectionWrapper.js
+++ b/src/helpers/CollectionWrapper.js
@@ -403,7 +403,8 @@ export default class CollectionWrapper extends Lightning.Component {
             }
         }
         else if (!isNaN(scroll)) {
-            this.wrapper[main] = scroll
+            this.wrapper[main] = scroll;
+            this._scrollTransition.reset(scroll, 1);
         }
     }
 

--- a/src/helpers/CollectionWrapper.js
+++ b/src/helpers/CollectionWrapper.js
@@ -404,7 +404,9 @@ export default class CollectionWrapper extends Lightning.Component {
         }
         else if (!isNaN(scroll)) {
             this.wrapper[main] = scroll;
-            this._scrollTransition.reset(scroll, 1);
+            if (this._scrollTransition) {
+                this._scrollTransition.reset(scroll, 1);
+            }
         }
     }
 


### PR DESCRIPTION
This fixes an issue that when you use `setIndex` when the component is _inactive_ and when `_cleanUp` from Carousel is called, it clears all the items because the `scrollTransition.targetValue` is not updated.

How to test this:

1) Create Carousel with multiple items so that when you navigate to the "middle" it cleans-up the first items
2) Carousel alpha = 0
3) Carousel.setIndex(0)
4) Carousel.right()