### PR TITLE
collectionwrapper: fix remove when last item is not a component

### DIFF
--- a/src/helpers/CollectionWrapper.js
+++ b/src/helpers/CollectionWrapper.js
@@ -212,14 +212,10 @@ export default class CollectionWrapper extends Lightning.Component {
 
     remove(target, options = {}) {
         if(this.hasItems && target.assignedID) {
-            const itemWrappers = this.itemWrappers;
             for(let i = 0; i < this._items.length; i++) {
                 let item = this._items[i];
-                if(itemWrappers[i] && itemWrappers[i].component.isAlive) {
-                    item = itemWrappers[i].component;
-                }
                 if(target.assignedID === item.assignedID) {
-                    if(i === this._items.length-1 && item.hasFocus()) {
+                    if(i === this._items.length - 1 && this._index === this._items.length - 1) {
                         this._index = this._index - 1;
                     }
                     return this.removeAt(i, 1, options);


### PR DESCRIPTION
When removing the last item from a CollectionWrapper using the remove method and that last item is out of bounds (it's not rendered), it throws an exception. This PR attempts to fix it.

[Playground example](https://lightningjs.io/playground/#N4IgJgpgDhB2mwMYEsIGcQC5QAEA2yA5gBYAusyshAVmgPSID2AThFiGaVGpnQ2LAB0aANYBPKAENEIwZABudfETIUqtBiwg4ATIICMegAwgANCGUlylGvQCuydp269+Q0ROmyFSglbW2dA4gAL7maIjMyFCkGNggeJJ2SMSCtFigAGbIeGyYCUkpaRjmTJDsADqwAAS1dbXIALZQLKTVAIJQUNWZzIyN1QDkgnSdUMWDANxV9fUzs7UA7pRgjIuCkqSk0sQAkrBoMIikLAAUy-BrgnhUAJTTsPMLTAdtjDHIjAfVALzVwGhtoQIJh-otQfoAJw6IymarECFGAAcsOqiFykmYAGFGHgWKCjAAPIwk0kkkIhB4LWovQHVSRdX7VWAQRYdLqnd6kT4He5PWarRB2RpwUiCABGjDAYg2XTgYCxxByYFODPGgMkwMEwNIWMksHkkjQp1ufJqdTM4Gg8rgKHQWAA2iARmNiiAALphECu9LxbK5dg+kogMp5EBNFrMNoAGRU1ioPT6A0GllUNg0TFYUyqEda-2qsbpIUT-SGqfjgQcgyqNZZhMjbUgmSSeDa6KNaHZ3QghNI8s7sf8NkEYwIiE2PP+-I13MQ1QA+n3mok+yap+aFqxSHZmDVgPzqdVwdUoTDTAfqQiT8jYReFgBZMSF0ig-cbw+zY+n2-vj91K-6De56-n+1SkBIIIFsggLAaBszIEuAAqEGgrsS6wXBdSHNINiggArD+mF1AhECNDwHTMMwkgyr0-SnMAuRUKQAFGGE1Rrj8AB87HACEpoYX+IR3tUQnvqJ-LzjqABijBCmgEAqrc66HluO41Mx0GCECpyDI+z6DLc-Lie+87EPqYC5AAorAfbMGub6HrSbSJICaGkUyGloFpmo6Xp0GkAZggkWRDqed5hC+U+-mBcFXmMYQzHVAAtCe7rCWF2m6VFgKBawjSMPIECnC5pBuY0hliVUxntmgnZldUPZ9vAA5xgEgg4s0XyispWHbLOC5LlAK5FUpDnUqpu49X+rDHKCpDMHYEACR+TB4swBKEpkmQkltW3LYex4woRoFXkd+11KJ9TGfU86ZLJdjGqN6VKl5UikIgxD0WiuL4tURJbTt21GCJFVXbWN3JHdcn2c9mlvR9X2rb9-1A7tmQg0Z4O9ROc46keyBgMx9nVBNNRHSJ059cguMQG0xAQHGxOk9U5OiSElqQDA8C2qgcROuWAQZloloC+m9iOJ6XrbOKcQgJIeB4KEQA)

To trigger the error, simply press Enter.